### PR TITLE
Recommision Reactor Tooltip fixed to show age and failure risks

### DIFF
--- a/mod/modules/production_panel/support/cui_production_data.lua
+++ b/mod/modules/production_panel/support/cui_production_data.lua
@@ -41,6 +41,14 @@ function GetPanelData()
     m_player = player
     m_city = city
     m_queue = city:GetBuildQueue()
+    
+    -- ak begin
+    -- AddReactorProjectData in ToolTipLoader_Expansion2.lua expects a global pBuildQueue to exist even
+    -- though it doesn't use it for anything. Without it the tooltip for the Recommision Nuclear Reactor
+    -- project does not show the age of the reactor and the current failure risks
+
+    pBuildQueue = m_queue;
+    -- ak end
 
     local d = GetCityDistricts()
     local w = GetCityWonders()


### PR DESCRIPTION
In the standard game the tooltip for the Recommission Nuclear Reactor project in the production queue shows the age of that city's reactor and the likely failures due to age. With CUI enabled this info is not shown. 
This seems to be due to the Firaxis code that generates the tooltip assuming that there will be a global variable containing a reference to the city's build queue (even though it never uses it!), which is not the case with the mods code.
This is just a quick fix that puts the global var back, and all seems well!

cheers
ak