### PR TITLE
fix: error were spies can not accept any missions

### DIFF
--- a/mod/modules/espionage_panel/base/espionagechooser.lua
+++ b/mod/modules/espionage_panel/base/espionagechooser.lua
@@ -378,7 +378,7 @@ function AddAvailableOffensiveOperation(operation, result, targetCityPlot)
         missionInstance.MissionButton:RegisterCallback(
             Mouse.eLClick,
             function()
-                OnMissionSelected(operation, missionInstance)
+                OnMissionSelected(operation, missionInstance, targetCityPlot)
             end
         )
     end
@@ -403,8 +403,8 @@ function OnCounterspySelected(districtPlot)
 end
 
 -- ===========================================================================
-function OnMissionSelected(operation, instance)
-    LuaEvents.EspionageChooser_ShowMissionBriefing(operation.Hash, m_spy:GetID())
+function OnMissionSelected(operation, instance, targetCityPlot)
+    LuaEvents.EspionageChooser_ShowMissionBriefing(operation.Hash, m_spy:GetID(), targetCityPlot)
 
     -- Hide all selection borders before selecting another
     for i = 1, m_MissionStackIM.m_iCount, 1 do


### PR DESCRIPTION
Error was coming from the espionage popup file. The show mission briefing function required the target city as an argument also. Simply added the target city plot solved the issue.